### PR TITLE
Improve AI and UI accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>✨</text></svg>">
 </head>
 <body>
-    <canvas id="gameCanvas"></canvas>
+    <canvas id="gameCanvas" role="img" aria-label="Gameplay area"></canvas>
 
     <div id="game-hud" class="hidden">
         <div id="hud-top">
@@ -58,7 +58,7 @@
     
     <audio id="bg-music" loop src="music.wav"></audio>
 
-    <script src="data.js"></script>
-    <script src="script.js"></script>
+    <script src="data.js" defer></script>
+    <script src="script.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- adjust shooter enemy AI to keep preferred distance
- sanitize upgrade card creation
- pause/resume when tab visibility changes
- add accessibility role to canvas
- defer script loading for faster startup

## Testing
- `npm test` *(fails: ENOENT cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684642c1b3cc8324be90b7e36d309653