### PR TITLE
Improve map variety and wave behavior

### DIFF
--- a/data.js
+++ b/data.js
@@ -6,6 +6,33 @@ const FACTIONS = {
     NEUTRAL: 'Neutral',
 };
 
+function generateMapRegions(width, height) {
+    const regions = [];
+    const count = 20;
+    for (let i = 0; i < count; i++) {
+        const w = 800 + Math.random() * 1200;
+        const h = 800 + Math.random() * 1200;
+        const x = Math.random() * (width - w);
+        const y = Math.random() * (height - h);
+        let faction, name, color;
+        if (Math.random() < 0.7) {
+            faction = null;
+            name = 'Dead Space';
+            color = '#222831';
+        } else if (Math.random() < 0.5) {
+            faction = FACTIONS.PIRATE;
+            name = 'Pirate Outpost';
+            color = '#331f20';
+        } else {
+            faction = FACTIONS.SAMA;
+            name = 'Sama Enclave';
+            color = '#203030';
+        }
+        regions.push({ name, faction, color, x, y, width: w, height: h });
+    }
+    return regions;
+}
+
 const CONFIG = {
     PLAYER: {
         RADIUS: 12, MAX_HP: 100, SPEED: 1.7, ROTATION_SPEED: 0.08, FRICTION: 0.9, INVINCIBILITY_DURATION: 1000, MAGNET_RADIUS: 120,
@@ -26,16 +53,14 @@ const CONFIG = {
         GRAVITON: { RADIUS: 16, HP: 100, SPEED: 0.5, DAMAGE: 10, XP: 25, COLOR: '#4d908e', BEHAVIOR: 'graviton', GRAVITY: 200, FACTION: FACTIONS.PIRATE }, // Graviton remains a super-source
         CLOAKER: { RADIUS: 9, HP: 25, SPEED: 1.2, DAMAGE: 12, XP: 18, COLOR: '#577590', BEHAVIOR: 'cloak', CLOAK_DUR: 3000, UNCLOAK_DUR: 2000, GRAVITY: 1, FACTION: FACTIONS.PIRATE },
         HEALER: { RADIUS: 10, HP: 40, SPEED: 0.9, DAMAGE: 5, XP: 20, COLOR: '#f8961e', BEHAVIOR: 'heal', HEAL_RATE: 1000, HEAL_AMOUNT: 5, HEAL_RADIUS: 150, GRAVITY: 2, FACTION: FACTIONS.PIRATE },
-        SAMA_TROOP: { RADIUS: 10, HP: 18, SPEED: 1.2, DAMAGE: 8, XP: 8, COLOR: '#b5838d', BEHAVIOR: 'wander', GRAVITY: 2, FACTION: FACTIONS.SAMA },
+        SAMA_TROOP: { RADIUS: 10, HP: 18, SPEED: 1.2, DAMAGE: 8, XP: 8, COLOR: '#ffffff', BEHAVIOR: 'wander', GRAVITY: 2, FACTION: FACTIONS.SAMA },
+        SAMA_GUARD: { RADIUS: 12, HP: 30, SPEED: 1.0, DAMAGE: 12, XP: 12, COLOR: '#ffffff', BEHAVIOR: 'chase', GRAVITY: 2, FACTION: FACTIONS.SAMA },
+        SAMA_SNIPER: { RADIUS: 9, HP: 20, SPEED: 0.8, DAMAGE: 15, XP: 15, COLOR: '#ffffff', BEHAVIOR: 'shoot', FIRE_RATE: 2200, PREF_DIST: 350, GRAVITY: 2, FACTION: FACTIONS.SAMA },
     },
     MAP: {
         WIDTH: 9000,
         HEIGHT: 9000,
-        REGIONS: [
-            { name: 'Pirate Space', faction: FACTIONS.PIRATE, x: 0, y: 0, width: 3000, height: 9000 },
-            { name: 'Dead Space', faction: null, x: 3000, y: 0, width: 3000, height: 9000 },
-            { name: 'Sama Space', faction: FACTIONS.SAMA, x: 6000, y: 0, width: 3000, height: 9000 },
-        ],
+        REGIONS: generateMapRegions(9000, 9000),
     },
     WEAPONS: {
         // All projectiles now have a tiny amount of gravity

--- a/script.js
+++ b/script.js
@@ -540,19 +540,17 @@ document.addEventListener('DOMContentLoaded', () => {
         if (state.wave > 4) waveEnemyTypes.push(CONFIG.ENEMY.CLOAKER);
         if (state.wave > 5) waveEnemyTypes.push(CONFIG.ENEMY.GRAVITON);
         if (state.wave > 6) waveEnemyTypes.push(CONFIG.ENEMY.HEALER);
-
+        const spawnRadius = 600;
         for (let i = 0; i < numEnemies; i++) {
-            const side = Math.floor(Math.random() * 4);
-            let x, y;
-            const spawnDist = 100;
-            switch(side) {
-                case 0: x = Math.random() * canvas.width; y = -spawnDist; break;
-                case 1: x = canvas.width + spawnDist; y = Math.random() * canvas.height; break;
-                case 2: x = Math.random() * canvas.width; y = canvas.height + spawnDist; break;
-                case 3: x = -spawnDist; y = Math.random() * canvas.height; break;
-            }
+            const angle = Math.random() * Math.PI * 2;
+            const dist = 300 + Math.random() * spawnRadius;
+            const x = state.player.x + Math.cos(angle) * dist;
+            const y = state.player.y + Math.sin(angle) * dist;
             const config = waveEnemyTypes[Math.floor(Math.random() * waveEnemyTypes.length)];
-            state.enemies.push(Enemy.create(config, x + state.camera.x, y + state.camera.y));
+            const enemy = Enemy.create(config, x, y);
+            enemy.isWave = true;
+            enemy.color = '#ff0000';
+            state.enemies.push(enemy);
         }
     }
 
@@ -567,7 +565,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 const x = region.x + Math.random() * region.width;
                 const y = region.y + Math.random() * region.height;
                 const cfg = configs[Math.floor(Math.random() * configs.length)];
-                state.enemies.push(Enemy.create(cfg, x, y));
+                const enemy = Enemy.create(cfg, x, y);
+                if (cfg.FACTION === FACTIONS.SAMA) enemy.color = '#ffffff';
+                else enemy.color = '#ffa500';
+                enemy.isWave = false;
+                state.enemies.push(enemy);
             }
         });
     }
@@ -678,7 +680,8 @@ document.addEventListener('DOMContentLoaded', () => {
         handleGravity(dt);
         state.particles = state.particles.filter(p => p.lifespan > 0);
         state.particles.forEach(p => p.update(dt));
-        if (state.enemies.length === 0 && state.gameState === 'PLAYING') nextWave();
+        const remainingWave = state.enemies.filter(e => e.isWave).length;
+        if (remainingWave === 0 && state.gameState === 'PLAYING') nextWave();
         state.camera.x = state.player.x - canvas.width / 2;
         state.camera.y = state.player.y - canvas.height / 2;
     }
@@ -775,7 +778,18 @@ document.addEventListener('DOMContentLoaded', () => {
         const scaleX = dom.minimap.width / state.map.WIDTH;
         const scaleY = dom.minimap.height / state.map.HEIGHT;
         mCtx.clearRect(0,0,dom.minimap.width, dom.minimap.height);
-        CONFIG.MAP.REGIONS.forEach(r => { mCtx.fillStyle = r.color; mCtx.fillRect(r.x*scaleX, r.y*scaleY, r.width*scaleX, r.height*scaleY); });
+        CONFIG.MAP.REGIONS.forEach(r => {
+            mCtx.fillStyle = r.color || '#444';
+            mCtx.fillRect(r.x*scaleX, r.y*scaleY, r.width*scaleX, r.height*scaleY);
+            mCtx.fillStyle = '#fff';
+            mCtx.font = '10px sans-serif';
+            mCtx.textAlign = 'center';
+            mCtx.fillText(r.name, (r.x + r.width/2)*scaleX, (r.y + r.height/2)*scaleY);
+        });
+        state.enemies.forEach(e => {
+            mCtx.fillStyle = e.color;
+            mCtx.fillRect(e.x*scaleX-1, e.y*scaleY-1, 2, 2);
+        });
         mCtx.fillStyle = '#00f5d4';
         mCtx.beginPath();
         mCtx.arc(state.player.x*scaleX, state.player.y*scaleY, 3, 0, Math.PI*2);
@@ -790,7 +804,18 @@ document.addEventListener('DOMContentLoaded', () => {
         const scaleX = canvasMap.width / state.map.WIDTH;
         const scaleY = canvasMap.height / state.map.HEIGHT;
         mCtx.clearRect(0,0,canvasMap.width,canvasMap.height);
-        CONFIG.MAP.REGIONS.forEach(r => { mCtx.fillStyle = r.color; mCtx.fillRect(r.x*scaleX, r.y*scaleY, r.width*scaleX, r.height*scaleY); });
+        CONFIG.MAP.REGIONS.forEach(r => {
+            mCtx.fillStyle = r.color || '#444';
+            mCtx.fillRect(r.x*scaleX, r.y*scaleY, r.width*scaleX, r.height*scaleY);
+            mCtx.fillStyle = '#fff';
+            mCtx.font = '16px sans-serif';
+            mCtx.textAlign = 'center';
+            mCtx.fillText(r.name, (r.x + r.width/2)*scaleX, (r.y + r.height/2)*scaleY);
+        });
+        state.enemies.forEach(e => {
+            mCtx.fillStyle = e.color;
+            mCtx.fillRect(e.x*scaleX-2, e.y*scaleY-2, 4, 4);
+        });
         mCtx.fillStyle = '#00f5d4';
         mCtx.beginPath();
         mCtx.arc(state.player.x*scaleX, state.player.y*scaleY, 5, 0, Math.PI*2);


### PR DESCRIPTION
## Summary
- generate random map regions with 70% dead space
- color-code enemies by type and spawn wave enemies near player
- keep wave count based on wave enemies only
- display enemies with individual colors on maps

## Testing
- `node --check data.js`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68465473f5e48324a2d7d425ba465e5b