### PR TITLE
Improve map scale and enemy AI

### DIFF
--- a/data.js
+++ b/data.js
@@ -6,6 +6,41 @@ const FACTIONS = {
     NEUTRAL: 'Neutral',
 };
 
+function rectsOverlap(a, b) {
+    return !(a.x + a.width <= b.x || b.x + b.width <= a.x ||
+             a.y + a.height <= b.y || b.y + b.height <= a.y);
+}
+
+function generateMapRegions(width, height) {
+    const regions = [];
+    const count = 20;
+    let attempts = 0;
+    while (regions.length < count && attempts < count * 50) {
+        attempts++;
+        const w = 15000 + Math.random() * 10000;
+        const h = 15000 + Math.random() * 10000;
+        const x = Math.random() * (width - w);
+        const y = Math.random() * (height - h);
+        let faction, name, color;
+        if (Math.random() < 0.7) {
+            faction = null;
+            name = 'Dead Space';
+            color = '#222831';
+        } else if (Math.random() < 0.5) {
+            faction = FACTIONS.PIRATE;
+            name = 'Pirate Outpost';
+            color = '#331f20';
+        } else {
+            faction = FACTIONS.SAMA;
+            name = 'Sama Enclave';
+            color = '#203030';
+        }
+        const region = { name, faction, color, x, y, width: w, height: h };
+        if (regions.every(r => !rectsOverlap(r, region))) regions.push(region);
+    }
+    return regions;
+}
+
 const CONFIG = {
     PLAYER: {
         RADIUS: 12, MAX_HP: 100, SPEED: 1.7, ROTATION_SPEED: 0.08, FRICTION: 0.9, INVINCIBILITY_DURATION: 1000, MAGNET_RADIUS: 120,
@@ -26,16 +61,14 @@ const CONFIG = {
         GRAVITON: { RADIUS: 16, HP: 100, SPEED: 0.5, DAMAGE: 10, XP: 25, COLOR: '#4d908e', BEHAVIOR: 'graviton', GRAVITY: 200, FACTION: FACTIONS.PIRATE }, // Graviton remains a super-source
         CLOAKER: { RADIUS: 9, HP: 25, SPEED: 1.2, DAMAGE: 12, XP: 18, COLOR: '#577590', BEHAVIOR: 'cloak', CLOAK_DUR: 3000, UNCLOAK_DUR: 2000, GRAVITY: 1, FACTION: FACTIONS.PIRATE },
         HEALER: { RADIUS: 10, HP: 40, SPEED: 0.9, DAMAGE: 5, XP: 20, COLOR: '#f8961e', BEHAVIOR: 'heal', HEAL_RATE: 1000, HEAL_AMOUNT: 5, HEAL_RADIUS: 150, GRAVITY: 2, FACTION: FACTIONS.PIRATE },
-        SAMA_TROOP: { RADIUS: 10, HP: 18, SPEED: 1.2, DAMAGE: 8, XP: 8, COLOR: '#b5838d', BEHAVIOR: 'wander', GRAVITY: 2, FACTION: FACTIONS.SAMA },
+        SAMA_TROOP: { RADIUS: 10, HP: 18, SPEED: 1.2, DAMAGE: 8, XP: 8, COLOR: '#ffffff', BEHAVIOR: 'wander', GRAVITY: 2, FACTION: FACTIONS.SAMA },
+        SAMA_GUARD: { RADIUS: 12, HP: 30, SPEED: 1.0, DAMAGE: 12, XP: 12, COLOR: '#ffffff', BEHAVIOR: 'chase', GRAVITY: 2, FACTION: FACTIONS.SAMA },
+        SAMA_SNIPER: { RADIUS: 9, HP: 20, SPEED: 0.8, DAMAGE: 15, XP: 15, COLOR: '#ffffff', BEHAVIOR: 'shoot', FIRE_RATE: 2200, PREF_DIST: 350, GRAVITY: 2, FACTION: FACTIONS.SAMA },
     },
     MAP: {
-        WIDTH: 9000,
-        HEIGHT: 9000,
-        REGIONS: [
-            { name: 'Pirate Space', faction: FACTIONS.PIRATE, x: 0, y: 0, width: 3000, height: 9000 },
-            { name: 'Dead Space', faction: null, x: 3000, y: 0, width: 3000, height: 9000 },
-            { name: 'Sama Space', faction: FACTIONS.SAMA, x: 6000, y: 0, width: 3000, height: 9000 },
-        ],
+        WIDTH: 367200,
+        HEIGHT: 367200,
+        REGIONS: generateMapRegions(367200, 367200),
     },
     WEAPONS: {
         // All projectiles now have a tiny amount of gravity

--- a/script.js
+++ b/script.js
@@ -71,11 +71,12 @@ document.addEventListener('DOMContentLoaded', () => {
             this.wanderTimer = 0; this.wanderAngle = Math.random() * Math.PI * 2;
         }
         update(dt) {
-            const target = this.findTarget();
+            let target = this.findTarget();
+            if (this.isWave && !target) target = state.player;
             if (target) {
                 const dx = target.x - this.x; const dy = target.y - this.y; const dist = Math.sqrt(dx * dx + dy * dy);
                 if (dist > 0) { this.x += (dx / dist) * this.speed * dt; this.y += (dy / dist) * this.speed * dt; }
-            } else if (this.behavior === 'wander') {
+            } else if (this.behavior === 'wander' || !this.isWave) {
                 this.wanderTimer -= dt * (1000 / CONFIG.TARGET_FPS);
                 if (this.wanderTimer <= 0) { this.wanderAngle = Math.random() * Math.PI * 2; this.wanderTimer = 1000 + Math.random() * 2000; }
                 this.x += Math.cos(this.wanderAngle) * this.speed * 0.5 * dt;
@@ -121,19 +122,28 @@ document.addEventListener('DOMContentLoaded', () => {
     class ShooterEnemy extends Enemy {
         constructor(x, y, config) { super(x, y, config); this.fireCooldown = config.FIRE_RATE; }
         update(dt) {
-            const enemyTarget = this.findTarget();
-            const player = state.player; const target = enemyTarget || player;
-            const dx = target.x - this.x; const dy = target.y - this.y; const dist = Math.sqrt(dx * dx + dy * dy); const prefer = this.config.PREF_DIST;
-            if (dist > prefer) {
-                const spd = this.speed * Math.min(1, (dist - prefer) / prefer);
-                this.x += (dx / dist) * spd * dt; this.y += (dy / dist) * spd * dt;
-            } else if (dist < prefer * 0.8) {
-                const spd = this.speed * Math.min(1, (prefer * 0.8 - dist) / prefer);
-                this.x -= (dx / dist) * spd * dt; this.y -= (dy / dist) * spd * dt;
+            let target = this.findTarget();
+            if (this.isWave && !target) target = state.player;
+            const moveTarget = this.isWave ? (target || state.player) : target;
+            if (moveTarget) {
+                const dx = moveTarget.x - this.x; const dy = moveTarget.y - this.y;
+                const dist = Math.sqrt(dx * dx + dy * dy); const prefer = this.config.PREF_DIST;
+                if (dist > prefer) {
+                    const spd = this.speed * Math.min(1, (dist - prefer) / prefer);
+                    this.x += (dx / dist) * spd * dt; this.y += (dy / dist) * spd * dt;
+                } else if (dist < prefer * 0.8) {
+                    const spd = this.speed * Math.min(1, (prefer * 0.8 - dist) / prefer);
+                    this.x -= (dx / dist) * spd * dt; this.y -= (dy / dist) * spd * dt;
+                }
+            } else if (!this.isWave) {
+                this.wanderTimer -= dt * (1000 / CONFIG.TARGET_FPS);
+                if (this.wanderTimer <= 0) { this.wanderAngle = Math.random() * Math.PI * 2; this.wanderTimer = 1000 + Math.random() * 2000; }
+                this.x += Math.cos(this.wanderAngle) * this.speed * 0.5 * dt;
+                this.y += Math.sin(this.wanderAngle) * this.speed * 0.5 * dt;
             }
             this.fireCooldown -= dt * (1000 / CONFIG.TARGET_FPS);
-            if (this.fireCooldown <= 0) {
-                const angle = Math.atan2(dy, dx);
+            if (this.fireCooldown <= 0 && moveTarget) {
+                const angle = Math.atan2(moveTarget.y - this.y, moveTarget.x - this.x);
                 state.projectiles.push(new EnemyProjectile(this.x, this.y, angle, { ...this.config, SPEED: 3, RADIUS: 4, DAMAGE: this.damage }, this));
                 this.fireCooldown = this.config.FIRE_RATE;
             }
@@ -540,19 +550,17 @@ document.addEventListener('DOMContentLoaded', () => {
         if (state.wave > 4) waveEnemyTypes.push(CONFIG.ENEMY.CLOAKER);
         if (state.wave > 5) waveEnemyTypes.push(CONFIG.ENEMY.GRAVITON);
         if (state.wave > 6) waveEnemyTypes.push(CONFIG.ENEMY.HEALER);
-
+        const spawnRadius = 600;
         for (let i = 0; i < numEnemies; i++) {
-            const side = Math.floor(Math.random() * 4);
-            let x, y;
-            const spawnDist = 100;
-            switch(side) {
-                case 0: x = Math.random() * canvas.width; y = -spawnDist; break;
-                case 1: x = canvas.width + spawnDist; y = Math.random() * canvas.height; break;
-                case 2: x = Math.random() * canvas.width; y = canvas.height + spawnDist; break;
-                case 3: x = -spawnDist; y = Math.random() * canvas.height; break;
-            }
+            const angle = Math.random() * Math.PI * 2;
+            const dist = 300 + Math.random() * spawnRadius;
+            const x = state.player.x + Math.cos(angle) * dist;
+            const y = state.player.y + Math.sin(angle) * dist;
             const config = waveEnemyTypes[Math.floor(Math.random() * waveEnemyTypes.length)];
-            state.enemies.push(Enemy.create(config, x + state.camera.x, y + state.camera.y));
+            const enemy = Enemy.create(config, x, y);
+            enemy.isWave = true;
+            enemy.color = '#ff0000';
+            state.enemies.push(enemy);
         }
     }
 
@@ -567,7 +575,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 const x = region.x + Math.random() * region.width;
                 const y = region.y + Math.random() * region.height;
                 const cfg = configs[Math.floor(Math.random() * configs.length)];
-                state.enemies.push(Enemy.create(cfg, x, y));
+                const enemy = Enemy.create(cfg, x, y);
+                if (cfg.FACTION === FACTIONS.SAMA) enemy.color = '#ffffff';
+                else enemy.color = '#ffa500';
+                enemy.isWave = false;
+                state.enemies.push(enemy);
             }
         });
     }
@@ -678,7 +690,8 @@ document.addEventListener('DOMContentLoaded', () => {
         handleGravity(dt);
         state.particles = state.particles.filter(p => p.lifespan > 0);
         state.particles.forEach(p => p.update(dt));
-        if (state.enemies.length === 0 && state.gameState === 'PLAYING') nextWave();
+        const remainingWave = state.enemies.filter(e => e.isWave).length;
+        if (remainingWave === 0 && state.gameState === 'PLAYING') nextWave();
         state.camera.x = state.player.x - canvas.width / 2;
         state.camera.y = state.player.y - canvas.height / 2;
     }
@@ -775,7 +788,18 @@ document.addEventListener('DOMContentLoaded', () => {
         const scaleX = dom.minimap.width / state.map.WIDTH;
         const scaleY = dom.minimap.height / state.map.HEIGHT;
         mCtx.clearRect(0,0,dom.minimap.width, dom.minimap.height);
-        CONFIG.MAP.REGIONS.forEach(r => { mCtx.fillStyle = r.color; mCtx.fillRect(r.x*scaleX, r.y*scaleY, r.width*scaleX, r.height*scaleY); });
+        CONFIG.MAP.REGIONS.forEach(r => {
+            mCtx.fillStyle = r.color || '#444';
+            mCtx.fillRect(r.x*scaleX, r.y*scaleY, r.width*scaleX, r.height*scaleY);
+            mCtx.fillStyle = '#fff';
+            mCtx.font = '10px sans-serif';
+            mCtx.textAlign = 'center';
+            mCtx.fillText(r.name, (r.x + r.width/2)*scaleX, (r.y + r.height/2)*scaleY);
+        });
+        state.enemies.forEach(e => {
+            mCtx.fillStyle = e.color;
+            mCtx.fillRect(e.x*scaleX-1, e.y*scaleY-1, 2, 2);
+        });
         mCtx.fillStyle = '#00f5d4';
         mCtx.beginPath();
         mCtx.arc(state.player.x*scaleX, state.player.y*scaleY, 3, 0, Math.PI*2);
@@ -790,7 +814,18 @@ document.addEventListener('DOMContentLoaded', () => {
         const scaleX = canvasMap.width / state.map.WIDTH;
         const scaleY = canvasMap.height / state.map.HEIGHT;
         mCtx.clearRect(0,0,canvasMap.width,canvasMap.height);
-        CONFIG.MAP.REGIONS.forEach(r => { mCtx.fillStyle = r.color; mCtx.fillRect(r.x*scaleX, r.y*scaleY, r.width*scaleX, r.height*scaleY); });
+        CONFIG.MAP.REGIONS.forEach(r => {
+            mCtx.fillStyle = r.color || '#444';
+            mCtx.fillRect(r.x*scaleX, r.y*scaleY, r.width*scaleX, r.height*scaleY);
+            mCtx.fillStyle = '#fff';
+            mCtx.font = '16px sans-serif';
+            mCtx.textAlign = 'center';
+            mCtx.fillText(r.name, (r.x + r.width/2)*scaleX, (r.y + r.height/2)*scaleY);
+        });
+        state.enemies.forEach(e => {
+            mCtx.fillStyle = e.color;
+            mCtx.fillRect(e.x*scaleX-2, e.y*scaleY-2, 4, 4);
+        });
         mCtx.fillStyle = '#00f5d4';
         mCtx.beginPath();
         mCtx.arc(state.player.x*scaleX, state.player.y*scaleY, 5, 0, Math.PI*2);


### PR DESCRIPTION
## Summary
- ensure regions don't overlap by checking bounds when generating
- scale map so crossing it at full speed takes about an hour
- keep normal enemies wandering and only let wave enemies chase the player
- spawn wave enemies near the player as before

## Testing
- `node --check data.js`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68465473f5e48324a2d7d425ba465e5b