### PR TITLE
Add hyperspace overlay effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 </head>
 <body>
     <canvas id="gameCanvas" role="img" aria-label="Gameplay area"></canvas>
+    <div id="hyperspace-overlay" aria-hidden="true"></div>
     <canvas id="minimap" aria-hidden="true"></canvas>
     <div id="map-overlay" class="hidden" aria-hidden="true">
         <canvas id="map-canvas"></canvas>

--- a/script.js
+++ b/script.js
@@ -14,6 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
         upgradeContainer: document.getElementById('upgrade-cards-container'), startButton: document.getElementById('start-button'),
         restartButton: document.getElementById('restart-button'), finalScore: document.getElementById('final-score'), finalWave: document.getElementById('final-wave'),
         minimap: document.getElementById('minimap'), mapOverlay: document.getElementById('map-overlay'), mapCanvas: document.getElementById('map-canvas'),
+        hyperspaceOverlay: document.getElementById('hyperspace-overlay'),
     };
 
     let state, musicStarted = false;
@@ -839,6 +840,7 @@ document.addEventListener('DOMContentLoaded', () => {
             dom.hyperValue.textContent = `${Math.floor(ratio * 100)}%`;
             dom.hyperBar.style.width = `${ratio * 100}%`;
         }
+        dom.hyperspaceOverlay.classList.toggle('active', state.hyperspaceActive);
 
         drawMiniMap();
         if (state.showMap) drawFullMap();

--- a/style.css
+++ b/style.css
@@ -236,3 +236,30 @@ button:hover {
     border: 2px solid var(--accent-color);
     background-color: #000;
 }
+
+#hyperspace-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 3;
+    opacity: 0;
+    mix-blend-mode: screen;
+    transition: opacity 0.3s ease;
+    background:
+        radial-gradient(circle at center, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0) 70%),
+        repeating-linear-gradient(45deg, rgba(0, 245, 212, 0.4) 0 2px, transparent 2px 8px),
+        repeating-linear-gradient(-45deg, rgba(155, 93, 229, 0.4) 0 2px, transparent 2px 8px);
+    animation: hyperspace-warp 1s linear infinite;
+}
+
+#hyperspace-overlay.active {
+    opacity: 0.8;
+}
+
+@keyframes hyperspace-warp {
+    from { background-position: 0 0, 0 0, 0 0; }
+    to { background-position: 0 50px, 0 200px, 0 -200px; }
+}


### PR DESCRIPTION
## Summary
- overlay element renders hyperspace effect when charge activates
- implement warp animation styles
- toggle effect from game script

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_6849bea39e648324b901572f07fa0390