### PR TITLE
Add hyperspace overlay effect

### DIFF
--- a/data.js
+++ b/data.js
@@ -69,7 +69,7 @@ const CONFIG = {
         GRAVITY_CONSTANT: 20, // Reduced further to minimize projectile attraction
         VELOCITY_DAMAGE_MODIFIER: 0.05,
     },
-    HYPERSPACE: { CHARGE_TIME: 30000 },
+    HYPERSPACE: { CHARGE_TIME: 30000, SPEED_MULTIPLIER: 10 },
     ENEMY: {
         // All enemies now have a small amount of gravity and faction assignments
         CHASER: { RADIUS: 10, HP: 20, SPEED: 1.0, DAMAGE: 10, XP: 10, COLOR: '#A0522D', BEHAVIOR: 'chase', GRAVITY: 2, FACTION: FACTIONS.PIRATE },

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 </head>
 <body>
     <canvas id="gameCanvas" role="img" aria-label="Gameplay area"></canvas>
+    <div id="hyperspace-overlay" aria-hidden="true"></div>
     <canvas id="minimap" aria-hidden="true"></canvas>
     <div id="map-overlay" class="hidden" aria-hidden="true">
         <canvas id="map-canvas"></canvas>

--- a/script.js
+++ b/script.js
@@ -14,6 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
         upgradeContainer: document.getElementById('upgrade-cards-container'), startButton: document.getElementById('start-button'),
         restartButton: document.getElementById('restart-button'), finalScore: document.getElementById('final-score'), finalWave: document.getElementById('final-wave'),
         minimap: document.getElementById('minimap'), mapOverlay: document.getElementById('map-overlay'), mapCanvas: document.getElementById('map-canvas'),
+        hyperspaceOverlay: document.getElementById('hyperspace-overlay'),
     };
 
     let state, musicStarted = false;
@@ -45,8 +46,9 @@ document.addEventListener('DOMContentLoaded', () => {
         update(dt) {
             // Use all keys as lowercase for consistency
             if (state.hyperspaceActive) {
-                this.vx = Math.cos(this.angle) * this.speed * 4;
-                this.vy = Math.sin(this.angle) * this.speed * 4;
+                const mult = CONFIG.HYPERSPACE.SPEED_MULTIPLIER;
+                this.vx = Math.cos(this.angle) * this.speed * mult;
+                this.vy = Math.sin(this.angle) * this.speed * mult;
             } else {
                 if (state.keys['w'] || state.keys['arrowup']) { this.vx += Math.cos(this.angle) * this.speed; this.vy += Math.sin(this.angle) * this.speed; createThrusterParticles(this); }
                 this.vx *= this.friction; this.vy *= this.friction;
@@ -839,6 +841,7 @@ document.addEventListener('DOMContentLoaded', () => {
             dom.hyperValue.textContent = `${Math.floor(ratio * 100)}%`;
             dom.hyperBar.style.width = `${ratio * 100}%`;
         }
+        dom.hyperspaceOverlay.classList.toggle('active', state.hyperspaceActive);
 
         drawMiniMap();
         if (state.showMap) drawFullMap();

--- a/style.css
+++ b/style.css
@@ -236,3 +236,30 @@ button:hover {
     border: 2px solid var(--accent-color);
     background-color: #000;
 }
+
+#hyperspace-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 3;
+    opacity: 0;
+    mix-blend-mode: screen;
+    transition: opacity 0.3s ease;
+    background:
+        radial-gradient(circle at center, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0) 70%),
+        repeating-linear-gradient(45deg, rgba(0, 245, 212, 0.4) 0 2px, transparent 2px 8px),
+        repeating-linear-gradient(-45deg, rgba(155, 93, 229, 0.4) 0 2px, transparent 2px 8px);
+    animation: hyperspace-warp 0.3s linear infinite;
+}
+
+#hyperspace-overlay.active {
+    opacity: 0.8;
+}
+
+@keyframes hyperspace-warp {
+    from { background-position: 0 0, 0 0, 0 0; }
+    to { background-position: 0 50px, 0 200px, 0 -200px; }
+}


### PR DESCRIPTION
## Summary
- overlay element renders hyperspace effect when charge activates
- implement warp animation styles
- toggle effect from game script
- make hyperspace dramatically faster using configurable speed multiplier

## Testing
- `node -c script.js`


------
https://chatgpt.com/codex/tasks/task_e_6849bea39e648324b901572f07fa0390