### PR TITLE
Add control panel and sector invasion news

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,12 +37,54 @@
             <button id="close-quests">Close</button>
         </div>
     </div>
+    <div id="control-panel" class="hidden" aria-hidden="true">
+        <div class="menu-card control-panel-card">
+            <div id="app-grid">
+                <div class="app-icon" data-app="diplomacy" aria-label="Diplomacy" role="button">🛡️</div>
+                <div class="app-icon" data-app="news" aria-label="News" role="button">📰</div>
+                <div class="app-icon" data-app="quests" aria-label="Quests" role="button">📜</div>
+                <div class="app-icon" data-app="skills" aria-label="Skills" role="button">🌿</div>
+                <div class="app-icon" data-app="stats" aria-label="Stats" role="button">📊</div>
+                <div class="app-icon" data-app="modifiers" aria-label="Modifiers" role="button">🧬</div>
+            </div>
+            <button id="close-control-panel">Close</button>
+        </div>
+    </div>
+    <div id="news-overlay" class="hidden" aria-hidden="true">
+        <div class="menu-card news-card">
+            <h2>News Feed</h2>
+            <ul id="news-list"></ul>
+            <button class="close-app" data-target="news-overlay">Close</button>
+        </div>
+    </div>
+    <div id="skill-overlay" class="hidden" aria-hidden="true">
+        <div class="menu-card skill-card">
+            <h2>Skill Tree</h2>
+            <pre id="skill-tree-view"></pre>
+            <button class="close-app" data-target="skill-overlay">Close</button>
+        </div>
+    </div>
+    <div id="stats-overlay" class="hidden" aria-hidden="true">
+        <div class="menu-card stats-card">
+            <h2>Player Stats</h2>
+            <pre id="stats-view"></pre>
+            <button class="close-app" data-target="stats-overlay">Close</button>
+        </div>
+    </div>
+    <div id="modifiers-overlay" class="hidden" aria-hidden="true">
+        <div class="menu-card modifiers-card">
+            <h2>Active Modifiers</h2>
+            <ul id="modifiers-list"></ul>
+            <button class="close-app" data-target="modifiers-overlay">Close</button>
+        </div>
+    </div>
     <div id="dialogue-overlay" class="hidden" aria-hidden="true">
         <div class="menu-card">
             <div id="dialogue-text"></div>
             <div id="dialogue-choices"></div>
         </div>
     </div>
+    <div id="news-popup" class="hidden" aria-live="polite"></div>
 
     <div id="game-hud" class="hidden">
         <div id="hud-top">
@@ -73,7 +115,7 @@
             <p class="tagline">Chart a course through hostile space.</p>
             <ul class="how-to">
                 <li>Move with <strong>WASD</strong> or <strong>Arrow Keys</strong></li>
-                <li>Auto-fire with the <strong>Mouse</strong></li>
+                <li>Toggle auto-fire with the <strong>Middle Mouse</strong></li>
                 <li>Press <strong>M</strong> to open the map</li>
             </ul>
             <button id="start-button">Begin Run</button>

--- a/style.css
+++ b/style.css
@@ -405,3 +405,73 @@ button:hover {
     from { background-position: 0 0, 0 0, 0 0; }
     to { background-position: 0 50px, 0 200px, 0 -200px; }
 }
+
+/* Control Panel and Apps */
+#control-panel,
+#news-overlay,
+#skill-overlay,
+#stats-overlay,
+#modifiers-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0,0,0,0.7);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 12;
+}
+
+#control-panel.visible,
+#news-overlay.visible,
+#skill-overlay.visible,
+#stats-overlay.visible,
+#modifiers-overlay.visible {
+    display: flex;
+}
+
+.control-panel-card {
+    max-width: 500px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    align-items: center;
+}
+
+#app-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(60px, 1fr));
+    gap: 10px;
+}
+
+.app-icon {
+    font-size: 32px;
+    padding: 10px;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    cursor: pointer;
+    text-align: center;
+    user-select: none;
+}
+
+.app-icon:hover {
+    background-color: rgba(0,0,0,0.3);
+}
+
+#news-popup {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background-color: var(--ui-bg-color);
+    border: 1px solid var(--border-color);
+    padding: 8px 12px;
+    border-radius: 6px;
+    z-index: 15;
+    cursor: pointer;
+}
+
+#news-popup.hidden {
+    display: none;
+}


### PR DESCRIPTION
## Summary
- implement new Control Panel overlay with app icons
- add News, Skill Tree, Stats and Modifiers overlays
- allow opening the control panel with `C` key and apps via icons
- middle mouse toggles auto-fire instead of `P`
- factions randomly invade other sectors and captured sector is reported via popup news
- show bullet about middle mouse in start menu

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684b4a9976f48324a94bccd034e3a5aa