### PR TITLE
Improve control panel UI and skill tree display

### DIFF
--- a/data.js
+++ b/data.js
@@ -56,11 +56,6 @@ const POI_TYPES = {
 
 const BIOME_TYPES = ['Nebula', 'Void Rift', 'Crystal Zone', 'Asteroid Field'];
 
-function rectsOverlap(a, b) {
-    return !(a.x + a.width <= b.x || b.x + b.width <= a.x ||
-             a.y + a.height <= b.y || b.y + b.height <= a.y);
-}
-
 function generateMapRegions(width, height) {
     const cols = 6, rows = 6;
     const cellW = Math.floor(width / cols);

--- a/index.html
+++ b/index.html
@@ -40,12 +40,30 @@
     <div id="control-panel" class="hidden" aria-hidden="true">
         <div class="menu-card control-panel-card">
             <div id="app-grid">
-                <div class="app-icon" data-app="diplomacy" aria-label="Diplomacy" role="button">🛡️</div>
-                <div class="app-icon" data-app="news" aria-label="News" role="button">📰</div>
-                <div class="app-icon" data-app="quests" aria-label="Quests" role="button">📜</div>
-                <div class="app-icon" data-app="skills" aria-label="Skills" role="button">🌿</div>
-                <div class="app-icon" data-app="stats" aria-label="Stats" role="button">📊</div>
-                <div class="app-icon" data-app="modifiers" aria-label="Modifiers" role="button">🧬</div>
+                <div class="app-icon" data-app="diplomacy" aria-label="Diplomacy" role="button">
+                    <span class="emoji">🛡️</span>
+                    <span class="label">Diplomacy</span>
+                </div>
+                <div class="app-icon" data-app="news" aria-label="News" role="button">
+                    <span class="emoji">📰</span>
+                    <span class="label">News</span>
+                </div>
+                <div class="app-icon" data-app="quests" aria-label="Quests" role="button">
+                    <span class="emoji">📜</span>
+                    <span class="label">Quests</span>
+                </div>
+                <div class="app-icon" data-app="skills" aria-label="Skills" role="button">
+                    <span class="emoji">🌿</span>
+                    <span class="label">Skills</span>
+                </div>
+                <div class="app-icon" data-app="stats" aria-label="Stats" role="button">
+                    <span class="emoji">📊</span>
+                    <span class="label">Stats</span>
+                </div>
+                <div class="app-icon" data-app="modifiers" aria-label="Modifiers" role="button">
+                    <span class="emoji">🧬</span>
+                    <span class="label">Mods</span>
+                </div>
             </div>
             <button id="close-control-panel">Close</button>
         </div>
@@ -60,7 +78,7 @@
     <div id="skill-overlay" class="hidden" aria-hidden="true">
         <div class="menu-card skill-card">
             <h2>Skill Tree</h2>
-            <pre id="skill-tree-view"></pre>
+            <div id="skill-tree-view" class="skill-tree"></div>
             <button class="close-app" data-target="skill-overlay">Close</button>
         </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -235,7 +235,25 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function updateSkillViewer() {
-        dom.skillTreeView.textContent = JSON.stringify(state.skillTree, null, 2);
+        dom.skillTreeView.innerHTML = '';
+        Object.entries(state.skillTree).forEach(([category, skills]) => {
+            const catDiv = document.createElement('div');
+            catDiv.className = 'skill-category';
+            const title = document.createElement('h3');
+            title.textContent = category.charAt(0).toUpperCase() + category.slice(1);
+            const ul = document.createElement('ul');
+            Object.entries(skills).forEach(([skill, level]) => {
+                const li = document.createElement('li');
+                const nameSpan = document.createElement('span');
+                nameSpan.textContent = skill;
+                const levelSpan = document.createElement('span');
+                levelSpan.textContent = level;
+                li.append(nameSpan, levelSpan);
+                ul.appendChild(li);
+            });
+            catDiv.append(title, ul);
+            dom.skillTreeView.appendChild(catDiv);
+        });
     }
 
     function updateStatsView() {

--- a/style.css
+++ b/style.css
@@ -433,11 +433,12 @@ button:hover {
 }
 
 .control-panel-card {
-    max-width: 500px;
+    max-width: 600px;
     display: flex;
     flex-direction: column;
     gap: 20px;
     align-items: center;
+    padding: 20px;
 }
 
 #app-grid {
@@ -447,17 +448,60 @@ button:hover {
 }
 
 .app-icon {
-    font-size: 32px;
-    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    font-size: 28px;
+    padding: 15px;
     border: 1px solid var(--border-color);
     border-radius: 6px;
     cursor: pointer;
-    text-align: center;
     user-select: none;
+    background-color: rgba(255,255,255,0.05);
+    transition: background-color 0.2s;
 }
 
 .app-icon:hover {
+    background-color: rgba(255,255,255,0.1);
+}
+
+.app-icon .label {
+    font-size: 14px;
+}
+
+#skill-tree-view {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    justify-content: center;
+}
+
+.skill-category {
     background-color: rgba(0,0,0,0.3);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    padding: 10px;
+    width: 160px;
+}
+
+.skill-category h3 {
+    color: var(--accent-color);
+    margin-bottom: 8px;
+    font-size: 18px;
+}
+
+.skill-category ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.skill-category li {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 4px;
+    font-size: 14px;
 }
 
 #news-popup {


### PR DESCRIPTION
## Summary
- enhance control panel with labeled icons
- style apps with better layout and visuals
- render skill tree in a simple categorized list instead of JSON
- remove unused `rectsOverlap` function

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b4c3a7f9c8324b66fb12eb058d85a